### PR TITLE
update Go client version to 1.24 and dependencies; bump version to 3.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 .vscode
 .idea
-go.sum
 main
 app
 *.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21-alpine
+FROM golang:1.24-alpine
 
 RUN apk add --no-cache bash
 WORKDIR /home/bringauto/virtual-fleet-management

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module virtual-fleet-management
 
-go 1.21
+go 1.24.0
 
-require github.com/bringauto/fleet-management-http-client-go v1.3.1
+require github.com/bringauto/fleet-management-http-client-go v1.3.2
 
-require golang.org/x/oauth2 v0.20.0 // indirect
+require golang.org/x/oauth2 v0.34.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/bringauto/fleet-management-http-client-go v1.3.2 h1:KyVdf+BmReqrmgiIOhJtXJh5iYBwnwLB4qsDGZ6Er70=
+github.com/bringauto/fleet-management-http-client-go v1.3.2/go.mod h1:djj7OdT1m3AiAcn+VAFrGbWOx30/h+0TnVXKwEamzYc=
+golang.org/x/oauth2 v0.34.0 h1:hqK/t4AKgbqWkdkcAeI8XLmbK+4m4G5YeQRrmiotGlw=
+golang.org/x/oauth2 v0.34.0/go.mod h1:lzm5WQJQwKZ3nwavOZ3IS5Aulzxi68dUSgRHujetwEA=

--- a/version.txt
+++ b/version.txt
@@ -1,1 +1,1 @@
-version=3.1.0
+version=3.1.1


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded Go toolchain to 1.24 (including base image reference).
  * Updated application dependencies for improved compatibility and security (client and OAuth library versions bumped).
  * Bumped application version to 3.1.1.
  * Adjusted ignore list to stop excluding the dependency checksum file.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->